### PR TITLE
Use app_label to lookup django app in Registry

### DIFF
--- a/tailwind/utils.py
+++ b/tailwind/utils.py
@@ -6,7 +6,9 @@ DJANGO_TAILWIND_APP_DIR = os.path.dirname(__file__)
 
 
 def get_app_path(app_name):
-    return apps.get_app_config(app_name).path
+    def get_app_path(app_name):
+    app_label = app_name.split('.')[-1]
+    return apps.get_app_config(app_label).path
 
 
 def get_tailwind_src_path(app_name):

--- a/tailwind/utils.py
+++ b/tailwind/utils.py
@@ -6,7 +6,6 @@ DJANGO_TAILWIND_APP_DIR = os.path.dirname(__file__)
 
 
 def get_app_path(app_name):
-    def get_app_path(app_name):
     app_label = app_name.split('.')[-1]
     return apps.get_app_config(app_label).path
 


### PR DESCRIPTION
Fix https://github.com/timonweb/django-tailwind/issues/33 by using the last segment of a the tailwind app's full package name when looking up the AppConfig using the _label_.