### PR TITLE
Change build system to Poetry core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,5 +38,5 @@ flake8 = "^3.8.4"
 black = "^20.8b1"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
As of Poetry v1.1, the core has been abstracted into its own `poetry.core` module. This upgrades the project's build system to this modernized version of Poetry.

_**Reference:**_ [Relevant section from Poetry's own `pyproject.toml` file](https://github.com/python-poetry/poetry/blob/master/pyproject.toml#L79-L81)