### PR TITLE
Fix docs about how to install development version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 ## Quick start
 
-1. Install the python package django-tailwind from pip
+1. Install the `django-tailwind` package via Pip:
 
-   `pip install django-tailwind`
+   `python -m pip install django-tailwind`
 
-   Alternatively, you can download or clone this repo and run `pip install -e .`.
+   Alternatively, you can install the latest development version via:
+
+   `python -m pip install git+https://github.com/timonweb/django-tailwind.git`
 
 2. Add `tailwind` to INSTALLED_APPS in **settings.py**
 


### PR DESCRIPTION
The current version of Pip can't do editable installs without setup.py, so at present running `pip install -e .` will fail.