### PR TITLE
Add JIT compiler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
    *NOTE:* By default, we install v2 of Tailwind CSS. If you want v1 Tailwind CSS you need to pass an additional `--legacy` parameter to the command:
    `python manage.py tailwind init --legacy theme`.
 
+   *NOTE:* If you'd like to use [Tailwind's experimental JIT compiler](https://github.com/tailwindlabs/tailwindcss-jit), you can pass the additional `--jit` parameter to the command:
+   `python manage.py tailwind init --jit theme`
+
 4. Add your newly created `theme` app to INSTALLED_APPS in **settings.py**
 
 5. In settings.py, register tailwind app by adding the following string:

--- a/README.md
+++ b/README.md
@@ -128,6 +128,46 @@ python manage.py tailwind update
 If there are updates, you'll see a log of updated dependencies.
 If there are no updates, this command will return no output.
 
+## Migrating to Tailwind's experimental JIT compiler
+*NOTE:* This migration guide is only for projects currently using tailwind v2. 
+### Migration steps
+1. Install the JIT compiler 
+
+   ```
+   npm install -D @tailwindcss/jit tailwindcss postcss autoprefixer
+   ```
+2. Update your `postcss.config.js` file
+   
+   Replace: 
+   ```
+   module.exports = {
+      plugins: {
+         ...
+         tailwindcss: {},
+         ...
+      }
+   }
+   ```
+   with
+   ```
+   module.exports = {
+      plugins: {
+         ...
+         '@tailwindcss/jit': {},
+         ...
+      }
+   }
+   ```
+3. Replace the `dev` script in `package.json`
+   ```
+   "scripts" : {
+      ...
+      "dev": "watch \"npm run dev:sass && npm run dev:postcss\" ../../ -p='/theme/'",
+      ...
+   }
+   ```
+4. Done! Use the project as normal.
+
 ## Bugs and suggestions
 
 If you have found a bug, please use the issue tracker on GitHub.

--- a/tailwind/app_template_v2_jit/apps.py
+++ b/tailwind/app_template_v2_jit/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class {{ camel_case_app_name }}Config(AppConfig):
+    name = '{{ app_name }}'

--- a/tailwind/app_template_v2_jit/static_src/.gitignore
+++ b/tailwind/app_template_v2_jit/static_src/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tailwind/app_template_v2_jit/static_src/package.json
+++ b/tailwind/app_template_v2_jit/static_src/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "django_tailwind",
+  "description": "",
+  "scripts": {
+    "start": "npm run dev",
+    "build": "npm run build:clean && npm run build:sass && npm run build:postcss && npm run build:cleancss",
+    "build:clean": "rimraf ../static/css",
+    "build:sass": "node-sass --output-style compressed src/styles.scss ../static/css/styles.css",
+    "build:postcss": "cross-env NODE_ENV=production postcss --config . --map false --output ../static/css/styles.css ../static/css/styles.css",
+    "build:cleancss": "cleancss -o ../static/css/styles.css ../static/css/styles.css",
+    "dev": "watch \"npm run dev:sass && npm run dev:postcss\" ../../ -p='/theme/'",
+    "dev:sass": "node-sass --output-style expanded --source-map true src/styles.scss ../static/css/styles.css",
+    "dev:postcss": "postcss --config . --map true --output ../static/css/styles.css ../static/css/styles.css"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "autoprefixer": "^10.0.2",
+    "clean-css-cli": "^4.3.0",
+    "cross-env": "^7.0.3",
+    "node-sass": "^5.0.0",
+    "postcss": "^8.1.9",
+    "postcss-cli": "^8.3.0",
+    "postcss-scss": "^3.0.4",
+    "rimraf": "^3.0.2",
+    "tailwindcss": "^2.0.1",
+    "@tailwindcss/jit": "^0.1.1",
+    "watch": "^1.0.2"
+  }
+}

--- a/tailwind/app_template_v2_jit/static_src/postcss.config.js
+++ b/tailwind/app_template_v2_jit/static_src/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    '@tailwindcss/jit': {},
+    autoprefixer: {},
+  },
+}

--- a/tailwind/app_template_v2_jit/static_src/src/styles.scss
+++ b/tailwind/app_template_v2_jit/static_src/src/styles.scss
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind/app_template_v2_jit/static_src/tailwind.config.js
+++ b/tailwind/app_template_v2_jit/static_src/tailwind.config.js
@@ -1,0 +1,17 @@
+// This is a minimal config.
+// If you need the full config, get it from here:
+// https://unpkg.com/browse/tailwindcss@latest/stubs/defaultConfig.stub.js
+module.exports = {
+    purge: [
+        // Templates within theme app (e.g. base.html)
+        '../templates/**/*.html',
+        // Templates in other apps. Uncomment the following line if it matches
+        // your project structure or change it to match.
+        // '../../templates/**/*.html',
+    ],
+    darkMode: false, // or 'media' or 'class'
+    theme: {
+        extend: {},
+    },
+    plugins: [],
+}

--- a/tailwind/app_template_v2_jit/templates/base.html
+++ b/tailwind/app_template_v2_jit/templates/base.html
@@ -1,0 +1,29 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+
+	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="X-UA-Compatible" content="ie=edge">
+		<title>Tailwind CSS Skeleton</title>
+		<meta name="description" content="">
+		<meta name="keywords" content="">
+		<meta name="author" content="">
+
+		<link rel="stylesheet" href="{% static 'css/styles.css' %}">
+	</head>
+
+	<body class="bg-grey-lightest font-serif leading-normal tracking-normal">
+
+		<div class="container mx-auto">
+			<section class="flex items-center justify-center h-screen">
+				<h1 class="text-5xl">Django + Tailwind = ❤️</h1>
+			</section>
+
+		</div>
+
+
+	</body>
+
+</html>

--- a/tailwind/management/commands/tailwind.py
+++ b/tailwind/management/commands/tailwind.py
@@ -36,6 +36,11 @@ Usage example:
             action="store_true",
             help="Installs Tailwind CSS version 1 (i.e. 'legacy')",
         )
+        parser.add_argument(
+            "--jit",
+            action="store_true",
+            help="Uses Tailwind CSS's JIT compiler (https://github.com/tailwindlabs/tailwindcss-jit)",
+        )
 
     def validate_app(self):
         try:
@@ -59,7 +64,7 @@ Usage example:
         )
 
     def handle_init_command(self, app_name, **options):
-        tailwind_version = "1" if options.get("legacy") else "2"
+        tailwind_version = "1" if options.get("legacy") else "2_jit" if options.get("jit") else "2"
         try:
             call_command(
                 "startapp",
@@ -75,6 +80,15 @@ Usage example:
                     f"Please add '{app_name}' to INSTALLED_APPS in settings.py."
                 )
             )
+            self.stdout.write(tailwind_version)
+            if tailwind_version == "2_jit" and app_name != "theme":
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Be sure to change the package.json dev script to ignore your theme directory ({app_name}).\n"
+                        f"You can use this replacement:\n"
+                        f'"dev": "watch \"npm run dev:sass && npm run dev:postcss\" ../../ -p=\'/{app_name}/\'",'
+                    )
+                )
         except Exception as err:
             raise CommandError(err)
 


### PR DESCRIPTION
Hi there, 
Yesterday [Tailwind announced an experimental Just In Time (JIT) compiler.](https://github.com/tailwindlabs/tailwindcss-jit). While it's experimental it appears to be somewhat stable and brings some awesome features. 

I implemented what I believe to be a working implementation of the JIT compiler. That being said, I'm not so well versed in sass so please let me know if it's inefficient to have the `node-sass` run on update or if only `postcss` needs to run (if so I'll make those quick changes)

Since there's no clearcut contribution guide, I'll just do my best to explain the changes:
* Creation of a `app_template_v2_jit` folder to hold the required changes for JIT compilation
* Changing the `npm dev` script to watch for changes across the project (This isn't the most efficient so I could see some improvement here if I have a chance to sit down and better understand postcss & watch)
* Changing the commands file to include initialization for jit projects, as well as a warning to change the `dev` script if they don't use the suggested theme app name.

I understand this is an experimental feature as of right now for tailwind, but I figured the more support the merrier. 