### PR TITLE
Fix: `bg-grey-lightest` => `bg-gray-50`

### DIFF
--- a/example/theme/templates/base.html
+++ b/example/theme/templates/base.html
@@ -9,7 +9,7 @@
 		{% tailwind_css %}
 	</head>
 
-	<body class="bg-grey-lightest font-serif leading-normal tracking-normal">
+	<body class="bg-gray-50 font-serif leading-normal tracking-normal">
 		<div class="container mx-auto">
 			<section class="flex items-center justify-center h-screen">
 				<h1 class="text-5xl">Django + Tailwind = ❤️</h1>

--- a/src/tailwind/app_template_v2/{{cookiecutter.app_name}}/templates/base.html
+++ b/src/tailwind/app_template_v2/{{cookiecutter.app_name}}/templates/base.html
@@ -9,7 +9,7 @@
 		{% tailwind_css %}
 	</head>
 
-	<body class="bg-grey-lightest font-serif leading-normal tracking-normal">
+	<body class="bg-gray-50 font-serif leading-normal tracking-normal">
 		<div class="container mx-auto">
 			<section class="flex items-center justify-center h-screen">
 				<h1 class="text-5xl">Django + Tailwind = ❤️</h1>


### PR DESCRIPTION
In the initial tailwind configuration that gets shipped, there is no `bg-grey-lightest` class. That is why I have replaced it with `bg-gray-50` 😊 

All the best, thanks for the great project!