### PR TITLE
Check if app_name is a valid Django app name, Fix #89

### DIFF
--- a/src/tailwind/app_template_v2/hooks/pre_gen_project.py
+++ b/src/tailwind/app_template_v2/hooks/pre_gen_project.py
@@ -1,0 +1,13 @@
+import re
+import sys
+
+
+APP_NAME_REGEX = r'^[_a-zA-Z][_a-zA-Z0-9]+$'
+
+app_name = '{{ cookiecutter.app_name }}'
+
+if not re.match(APP_NAME_REGEX, app_name):
+    print(f'ERROR: {app_name} is not a valid Django app name!')
+
+    # exits with status 1 to indicate failure
+    sys.exit(1)


### PR DESCRIPTION
Currently, there is no validation of the app_name variable.
If we enter 'custom ' (with a trailing space) or use any symbols in the app_name, it can break the whole app
For example, a space in app_name results in this:
```
class Custom Config(AppConfig):
    name = 'custom '

```
or a symbol like `#` can create an apps.py file with the following:
```
class Test#Config(AppConfig):
    name = 'test#'
```
which will raise syntax errors.

Using [this](https://cookiecutter.readthedocs.io/en/stable/advanced/hooks.html) as a reference, I've added a pre_gen_hook that checks if a user entered a valid app_name. This also fixes #89 