### PR TITLE
Enable tty in docker-example

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -17,5 +17,8 @@ services:
   tailwind:
     <<: *default-app
     command: "python manage.py tailwind start"
+    # Without tty, no stdin, and tailwind watcher aborts
+    # https://github.com/tailwindlabs/tailwindcss/issues/5324
+    tty: true
     ports:
       - "8383:8383"


### PR DESCRIPTION
Fixes #109.

This PR updates to docker example to set `tty` to `true` in order to prevent tailwind watch from aborting.

As described in #109 , when using docker, the watcher does not work anymore. It is a regression, as it used to work for me until I upgrade to a more recent version.

The problem seems to be described here: https://github.com/tailwindlabs/tailwindcss/issues/5324

On my end, the fix in this PR resolves the issue.