### PR TITLE
Make `django-browser-reload` optional to install

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,6 +8,14 @@
    python -m pip install django-tailwind
    ```
 
+   If you want to use automatic page reloads during development (see steps 10-12 below)
+   use the `[reload]` extras, which installs the `django-browser-reload` package
+   in addition:
+
+   ```bash
+   python -m pip install django-tailwind[reload]
+   ```
+
    Alternatively, you can install the latest development version via:
 
    ```bash

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,2 +1,2 @@
 django
-django-tailwind
+django-tailwind[reload]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.8.1"
 django = ">=3.2.14"
-django-browser-reload = "^1.6.0"
+django-browser-reload = {version = "^1.6.0", optional = true}
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.1"
@@ -41,6 +41,9 @@ black = "^23.1.0"
 Sphinx = "^4.3.1"
 recommonmark = "^0.7.1"
 sphinx-rtd-theme = "^1.2.0"
+
+[tool.poetry.extras]
+reload = ["django-browser-reload"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Makes `django-browser-reload` an optional dependency for Django Tailwind, which allows to reduce the amount of installed packages for production deployments. Developers can install the package using the extras notation, e.g.

```
pip install django-tailwind[reload]
```

Fixes #162