### PR TITLE
Adjust how project names are loaded internally

### DIFF
--- a/src/tailwind/utils.py
+++ b/src/tailwind/utils.py
@@ -7,8 +7,9 @@ DJANGO_TAILWIND_APP_DIR = os.path.dirname(__file__)
 
 
 def get_app_path(app_name):
-    app_label = app_name.split(".")[-1]
-    return apps.get_app_config(app_label).path
+    for config in apps.get_app_configs():
+        if config.name == app_name:
+            return config.path
 
 
 def get_tailwind_src_path(app_name):


### PR DESCRIPTION
## Problem

I have a `ui` app that I like to put my UI/Theme/Client specific code in. I wanted to use `django-tailwind` with an app located at `project.ui.tailwind`. So I initted using the CLI, moved the `theme` app and renamed it appropriately, setting the `AppConfig.label = 'project_tailwind'` to avoid overlaps with this package, as well as `TAILWIND_APP_NAME = 'project.ui.tailwind'`.

However, when I went to run the `install` command, I recieved this error:

```python
➜ python -m manage tailwind build
CommandError: 'project.ui.tailwind' isn't a Tailwind app
error: Recipe `manage` failed on line 27 with exit code 1
```

## Solution

Change the logic of `tailwind.utils.get_app_path` to lookup the tailwind app by dotted name.

---

I recognize this small change would be breaking, and you may not want to deal with the headaches.

All the tests pass, so maybe it's not as breaking of a change as I think, but I have yet to add any additional ones. If you're up for accepting this patch, I can go back and add some, as well as possibly breaking it up and adding some deprecation warnings to ease the transition.

Also willing to open an issue (should have probably started there instead of this drive-by PR).