### PR TITLE
doc: Add instructions on setting `NPM_BIN_PATH` on Windows

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -181,13 +181,13 @@ this case, you need to set the path to the `npm` executable in *settings.py* fil
 NPM_BIN_PATH = '/usr/local/bin/npm'
 ```
 
-On *Windows*, you may have npm on `$PATH` but it's `npm.cmd` rather than `npm`. If so, please override the default `NPM_BIN_PATH = 'npm'`:
+On *Windows*, you may have npm on `$PATH` but it's `npm.cmd` rather than `npm`. (You can call it from the terminal because `$PATHEXT` contains `.cmd`.) If so, please override the default `NPM_BIN_PATH = 'npm'`:
 
 ```python
 NPM_BIN_PATH = 'npm.cmd'
 ```
 
-Alternatively, you can also set the full path to `npm.cmd`. It might look like this:
+Alternatively (and for maximum reliability), you can use a fully qualified path. It might look like this:
 
 ```python
 NPM_BIN_PATH = r"C:\Program Files\nodejs\npm.cmd"
@@ -195,3 +195,10 @@ NPM_BIN_PATH = r"C:\Program Files\nodejs\npm.cmd"
 
 Please note that the path to the `npm` executable may be different for your system. To get the `npm` path, try running
 the command `which npm` in your terminal. (On *Windows*, please try `where npm` or `Get-Command npm`)
+
+If you share codes with others, you can search `$PATH` (and `$PATHEXT` on Windows) dynamically in *settings.py*:
+
+```python
+from shutil import which
+NPM_BIN_PATH = which("npm")
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -181,11 +181,17 @@ this case, you need to set the path to the `npm` executable in *settings.py* fil
 NPM_BIN_PATH = '/usr/local/bin/npm'
 ```
 
-On *Windows* it might look like this:
+On *Windows*, you may have npm on `$PATH` but it's `npm.cmd` rather than `npm`. If so, please override the default `NPM_BIN_PATH = 'npm'`:
+
+```python
+NPM_BIN_PATH = 'npm.cmd'
+```
+
+Alternatively, you can also set the full path to `npm.cmd`. It might look like this:
 
 ```python
 NPM_BIN_PATH = r"C:\Program Files\nodejs\npm.cmd"
 ```
 
 Please note that the path to the `npm` executable may be different for your system. To get the `npm` path, try running
-the command `which npm` in your terminal.
+the command `which npm` in your terminal. (On *Windows*, please try `where npm` or `Get-Command npm`)


### PR DESCRIPTION
This a repeated confusion: #11, #83, #92, #103, #114, …

Windows users may have no idea how POSIX / Linux / bash / GNU which / … differ from Windows / Command Prompt / PowerShell / …, and people may never learn the file suffix matters for `subprocess.run()`. Therefore, I add the instructions. I wish it'll be helpful.

Credits to https://github.com/timonweb/django-tailwind/issues/92#issuecomment-942836700.

Related PR: #144 which tried `shell=True`. (However I agree it's a bad idea.)