### PR TITLE
doc: Quote extras to avoid problems with glob qualifiers in shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install django-tailwind
 [RECOMMENDED IN DEV] If you want to use automatic page reloads during development use the `[reload]` extras, which installs the `django-browser-reload` package in addition:
 
  ```bash
- pip install django-tailwind[reload]
+ pip install 'django-tailwind[reload]'
  ```
 
 Check docs for the [Installation](https://django-tailwind.readthedocs.io/en/latest/installation.html) instructions.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,7 +13,7 @@
    in addition:
 
    ```bash
-   python -m pip install django-tailwind[reload]
+   python -m pip install 'django-tailwind[reload]'
    ```
 
    Alternatively, you can install the latest development version via:


### PR DESCRIPTION
Resolves #178

All `pip install …` are quoted, but `requirements.txt` are not.

> **Note**
>
> Use quotes around specifiers in the shell…
>
> Do not use quotes in requirement files. There is only one exception: pip v7.0 and v7.0.1 (from May 2015) required quotes around specifiers containing environment markers in requirement files.

https://pip.pypa.io/en/stable/reference/requirement-specifiers/

Relates-to: https://github.com/pypa/packaging.python.org/issues/1209
