### PR TITLE
Remove INTERNAL_IPS from docs & example

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,24 +52,16 @@
    TAILWIND_APP_NAME = 'theme'
    ```
 
-6. Make sure that the `INTERNAL_IPS` list is present in the `settings.py` file and contains the `127.0.0.1` ip address:
-
-   ```python
-   INTERNAL_IPS = [
-       "127.0.0.1",
-   ]
-   ```
-
-7. Install *Tailwind CSS* dependencies, by running the following command:
+6. Install *Tailwind CSS* dependencies, by running the following command:
 
    ```bash
    python manage.py tailwind install
    ```
 
-8. The *Django Tailwind* comes with a simple `base.html` template located at
+7. The *Django Tailwind* comes with a simple `base.html` template located at
    `your_tailwind_app_name/templates/base.html`. You can always extend or delete it if you already have a layout.
 
-9. If you are not using the `base.html` template that comes with *Django Tailwind*, add `{% tailwind_css %}` to
+8. If you are not using the `base.html` template that comes with *Django Tailwind*, add `{% tailwind_css %}` to
    the `base.html` template:
 
    ```html
@@ -85,7 +77,7 @@
    The `{% tailwind_css %}` tag includes Tailwind's stylesheet.
 
 
-10. Let's also add and configure `django_browser_reload`, which takes care of automatic page and css refreshes in the
+9. Let's also add and configure `django_browser_reload`, which takes care of automatic page and css refreshes in the
     development mode. Add it to `INSTALLED_APPS` in `settings.py`:
 
     ```python
@@ -97,7 +89,7 @@
     ]
     ```
 
-11. Staying in `settings.py`, add the middleware:
+10. Staying in `settings.py`, add the middleware:
 
     ```python
     MIDDLEWARE = [
@@ -110,7 +102,7 @@
     The middleware should be listed after any that encode the response, such as Django’s `GZipMiddleware`. The middleware
     automatically inserts the required script tag on HTML responses before `</body>` when `DEBUG` is `True.`
 
-12. Include `django_browser_reload` URL in your root `url.py`:
+11. Include `django_browser_reload` URL in your root `url.py`:
 
        ```python
        from django.urls import include, path
@@ -120,7 +112,7 @@
        ]
        ```
 
-13. Finally, you should be able to use *Tailwind CSS* classes in HTML. Start the development server by running the
+12. Finally, you should be able to use *Tailwind CSS* classes in HTML. Start the development server by running the
     following command in your terminal:
 
       ```bash

--- a/example/project/settings.py
+++ b/example/project/settings.py
@@ -25,10 +25,6 @@ DEBUG = True
 
 ALLOWED_HOSTS = ["*"]
 
-INTERNAL_IPS = [
-    "127.0.0.1",
-]
-
 # Application definition
 INSTALLED_APPS = [
     "django.contrib.staticfiles",


### PR DESCRIPTION
This used to be required, but AFAICT it no longer is.

(As I understand it, it is from the days when the `{% tailwind_css %}` tag had auto-reloading by default, but only in the case when your IP address matched `INTERNAL_IPS`. This has since been made explicit with a separate tag and a TAILWIND_DEV_MODE setting.)

I've grepped on 'debug' and 'INTERNAL_IPS' to make sure.