### PR TITLE
fix/npm errors on win32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-tailwind"
-version = "3.7.0"
+version = "3.8.0"
 description = "Tailwind CSS Framework for Django projects"
 authors = ["Tim Kamanin <tim@timonweb.com>"]
 license = "MIT"

--- a/src/tailwind/npm.py
+++ b/src/tailwind/npm.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import os
 
 from tailwind import get_config
 
@@ -21,7 +22,7 @@ class NPM:
 
     def command(self, *args):
         try:
-            subprocess.run([self.npm_bin_path] + list(args), cwd=self.cwd, check=True)
+            subprocess.run([self.npm_bin_path] + list(args), cwd=self.cwd, check=True, shell=True if os.name == 'nt' else False)
             return True
         except subprocess.CalledProcessError:
             sys.exit(1)


### PR DESCRIPTION
`Shell=True` is needed to make pure `npm` command work on Windows.
It resolved my issue, when `CommandError` appeared with exception from 33 row of `npm.py` file.

Fix as per [this stackoverflow thread](https://stackoverflow.com/questions/3022013/windows-cant-find-the-file-on-subprocess-call), worked in my case (Python 3.11, Windows 11).
