### PR TITLE
Fix link tag to provide file type

### DIFF
--- a/src/tailwind/templates/tailwind/tags/css.html
+++ b/src/tailwind/templates/tailwind/tags/css.html
@@ -1,6 +1,6 @@
 {% load static %}
 
-<link rel="stylesheet" href="{% if is_static_path %}{% static tailwind_css_path %}{% else %}{{ tailwind_css_path }}{% endif %}{% if v %}?v={{ v }}{% endif %}">
+<link rel="stylesheet" type="text/css" href="{% if is_static_path %}{% static tailwind_css_path %}{% else %}{{ tailwind_css_path }}{% endif %}{% if v %}?v={{ v }}{% endif %}">
 
 {# dev_mode is deprecated. Leaving it here to support legacy browser-sync based configs #}
 {% if dev_mode %}


### PR DESCRIPTION
I'm receiving an error from the hosted page on DigitalOcean.

The resource from “https://family-roots-gdplq.ondigitalocean.app/static/css/dist/styles.css” was blocked due to MIME type (“text/html”) mismatch (X-Content-Type-Options: nosniff).