### PR TITLE
Fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ repository.
 7. **Use Tailwind classes in your templates:**
    ```html
    {% load tailwind_tags %}
-   <link href="{% tailwind_css %}" rel="stylesheet">
+   {% tailwind_css %}
 
    <h1 class="text-4xl font-bold text-blue-600">Hello Tailwind!</h1>
    ```


### PR DESCRIPTION
In the point 7 it is stated the following:
```
7. Use Tailwind classes in your templates:

{% load tailwind_tags %}
<link href="{% tailwind_css %}" rel="stylesheet">

<h1 class="text-4xl font-bold text-blue-600">Hello Tailwind!</h1>
```

However it should be as follows:
```
7. Use Tailwind classes in your templates:

{% load tailwind_tags %}
{% tailwind_css %}

<h1 class="text-4xl font-bold text-blue-600">Hello Tailwind!</h1>
```

It's just a minor detail :)