### PR TITLE
Fix ImportError by replacing distlib.compat.raw_input with built-in input()

### DIFF
--- a/src/tailwind/management/commands/tailwind.py
+++ b/src/tailwind/management/commands/tailwind.py
@@ -4,7 +4,6 @@ import shlex
 import subprocess
 import sys
 
-from distlib.compat import raw_input
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
 
@@ -150,7 +149,7 @@ class Command(BaseCommand):
     def handle_init_command(self, **options):
         app_name = options["app_name"].strip() if options.get("app_name") else None
         if not app_name:
-            app_name_choice = raw_input("Enter Tailwind app name [theme]: ")
+            app_name_choice = input("Enter Tailwind app name [theme]: ")
             app_name = app_name_choice.strip() if app_name_choice.strip() else "theme"
 
         tailwind_version = (
@@ -158,7 +157,7 @@ class Command(BaseCommand):
         )
         app_template_choice = {"4s": "1", "4": "2", "3": "3", None: None}[tailwind_version]
         if not app_template_choice:
-            app_template_choice = raw_input("""Choose template:
+            app_template_choice = input("""Choose template:
 1 - Tailwind v4 Standalone - Simple and doesn't require Node.js
 2 - Tailwind v4 Full - All the bells and whistles, requires Node.js
 3 - Tailwind v3 Full - Legacy template for Tailwind v3 projects, requires Node.js
@@ -176,7 +175,7 @@ Enter choice [1-3]: """)
             if options.get("no_input"):
                 include_daisy_ui = options.get("include_daisy_ui", False)
             else:
-                include_daisy_ui_choice = raw_input("Include DaisyUI component library? (y/n): ")
+                include_daisy_ui_choice = input("Include DaisyUI component library? (y/n): ")
                 self.validate_input(include_daisy_ui_choice.lower(), ["y", "n"])
                 include_daisy_ui = include_daisy_ui_choice.lower() == "y"
 


### PR DESCRIPTION
## Problem

When installing `django-tailwind` without optional dependencies, users encounter an `ImportError`:

ModuleNotFoundError: No module named 'distlib'

This occurs because:
- `distlib` is not listed as a required dependency in `pyproject.toml` (only `django` and
`pytailwindcss` are)
- `distlib` is only available as a transitive dependency through the optional `cookiecutter` package
(`cookiecutter` → `virtualenv` → `distlib`)
- The management command imports `from distlib.compat import raw_input` at the module level

I encountered this issue when building a Docker image with `pip install django-tailwind`, which
doesn't include optional dependencies.

## Solution

Since `django-tailwind` requires Python 3.11+ (as specified in `pyproject.toml`), we can safely use
Python 3's built-in `input()` function instead of the Python 2/3 compatibility wrapper.

**Changes made:**
- Removed `from distlib.compat import raw_input` import
- Replaced all 3 occurrences of `raw_input()` with `input()`

In Python 3, `input()` behaves identically to Python 2's `raw_input()` (returns a string without
evaluation).

## Testing

- ✅ All existing tests pass (`uv run pytest`)
- ✅ Code formatted with ruff
- ✅ Verified the import no longer depends on an unlisted dependency

This fix ensures users can install and use `django-tailwind` with only the required dependencies
listed in `pyproject.toml`.